### PR TITLE
ci: :construction_worker: add workflow to auto-add PRs and Issues to board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,26 @@
+name: Add to project board
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+  pull_request: 
+    types:
+      - reopened
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-to-project:
+    name: Add to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue or PR to upcoming course board
+        uses: actions/add-to-project@v1.0.2
+        with: 
+          project-url: https://github.com/orgs/${{ github.repository_owner }}/projects/12
+          github-token: ${{ secrets.ADD_TO_BOARD }}


### PR DESCRIPTION
## Description

This CI workflow automatically adds the PR or Issue to the upcoming courses project board, to make it easier to track what needs to be done and what to work on.