### PR TITLE
build: :heavy_minus_sign: trim down on the number of dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,14 +34,10 @@ Imports:
     tidyr,
     workflows
 Suggests: 
-    devtools,
     gert,
     gitcreds,
-    RcppTOML,
-    remotes,
     rmarkdown,
     tarchetypes,
-    todor,
     usethis
 Encoding: UTF-8
 LazyData: true

--- a/sessions/smoother-collaboration.qmd
+++ b/sessions/smoother-collaboration.qmd
@@ -175,7 +175,7 @@ packages your data analysis project needs. There are a few ways of
             creating R packages.
 
         -   Installing packages is as easy as opening the project and
-            running `remotes::install_deps()` in the Console, which will
+            running `pak::pak()` in the Console, which will
             install all the packages listed in the `DESCRIPTION` file.
 
         -   Adding packages that you need is as easy as writing


### PR DESCRIPTION
## Description

After dropping using renv for developing the website, I can trim down on some of the extra dependencies that were there only for development work.

