### PR TITLE
docs(preamble): :memo: clarify Git and GitHub tasks sections

### DIFF
--- a/preamble/pre-course.qmd
+++ b/preamble/pre-course.qmd
@@ -116,12 +116,9 @@ cover *learning it* during this course. However, since version control
 is a fundamental component of any modern data analysis workflow and
 *should be used*, we **will be using it throughout the course**. If you
 have used or currently use Git and GitHub, you can skip these two tasks.
-If you *have not* used it, please do these tasks:
+If you **have not used Git or GitHub**, please do these tasks:
 
-1.  Follow the [pre-course tasks for Git and
-    GitHub](https://r-cubed-intro.rostools.org/preamble/pre-course.html#setting-up-git-and-github)
-    from the introduction course. Specifically, type in the RStudio
-    Console:
+1.  Type in the RStudio Console and follow the instructions:
 
     ``` {.r filename="Console"}
     # There will be a pop-up to type in your name (first and 
@@ -129,17 +126,15 @@ If you *have not* used it, please do these tasks:
     r3::setup_git_config()
     ```
 
-2.  **Please read** through the [Version Control
+2.  **Please ONLY read** through the [Version Control
     lesson](https://r-cubed-intro.rostools.org/sessions/version-control.html)
-    of the introduction course. *You don't need to do any of the
-    exercises or activities*, but you are welcome to do them if it will
-    help you learn or understand it better. For most of the course, we
+    of the introduction course, **but DO NOT DO any coding tasks or exercises**.
+    You are welcome to do them if it will
+    help you learn or understand it better, but it is **NOT** required. For most of the course, we
     will be using Git as shown in the [Using Git in
     RStudio](https://r-cubed-intro.rostools.org/sessions/version-control.html#using-git-in-rstudio)
     section. During the course, we will connect our projects to GitHub,
-    which is described in the [Synchronizing with
-    GitHub](https://r-cubed-intro.rostools.org/sessions/version-control.html#synchronizing-with-github)
-    section.
+    which is described below.
 
 Regardless of whether you've done the steps above or not, *everyone*
 needs to run:

--- a/preamble/pre-course.qmd
+++ b/preamble/pre-course.qmd
@@ -170,10 +170,14 @@ on it in the introduction course.
 
 Because we'll be pushing and pulling to GitHub throughout the course, as
 well as using GitHub to collaborate with others in the project work, you
-need to setup your computer to connect with GitHub. Read through and
-complete the tasks in the section [*authenticating with GitHub* of the
-*Connect to GitHub*
-Guide](https://guides.rostools.org/connect-github#authenticating-with-github)
+need to setup your computer to connect with GitHub. 
+
+```{r}
+#| echo: false
+#| eval: true
+#| results: asis
+cat(r3admin::read_common("github-authenticate.md"), sep = "\n")
+```
 
 ## Create an R Project {#sec-create-project}
 


### PR DESCRIPTION
## Description

Removes and simplifies the text for setting up Git (several people had issues) as well as directly inserting the tasks for the authentication to GitHub.

Closes #207

<!-- Please delete as appropriate: -->

## Checklist

- [x] Rendered website locally
