### PR TITLE
docs(sessions): :memo: need to include the `Title` in the description for things to work

### DIFF
--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -164,3 +164,14 @@ Exercises](../appendix/extra-exercises.qmd) section. It is still a
 work-in-progress, so there are only a few exercises available right now.
 :::
 :::::
+
+## Small fixes
+
+<!-- TODO: This isn't needed after a while -->
+
+We need to add a `Title:` field to the `DESCRIPTION` file in order for other
+sections of the course to work properly. Run this bit of code:
+
+```{.r filename="Console"}
+desc::desc_set("Title", "AdvancedR3")
+```


### PR DESCRIPTION
## Description

The current version of prodigenr doesn't add the title to the description file, which is needed for some usethis functions. This adds a small fix we have to do in the introduction section.

Closes #208 and closes #213

<!-- Please delete as appropriate: -->
Doesn't need a review.

## Checklist

- [x] Ran spell-check
- [x] Formatted Markdown
- [x] Rendered website locally
